### PR TITLE
Add script to count visits

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -8,6 +8,7 @@
 			href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🎞️</text></svg>"
 		/>
 		<title>Hvað er í bíó?</title>
+		<script src="https://cdn.usefathom.com/script.js" data-site="GFZYUASY" defer></script>
 		%sveltekit.head%
 	</head>
 

--- a/src/app.html
+++ b/src/app.html
@@ -8,6 +8,7 @@
 			href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🎞️</text></svg>"
 		/>
 		<title>Hvað er í bíó?</title>
+		<meta name="Hvað er í bíó er fljótlegt yfirlit yfir bíódagskrá kvöldsins á öllu landinu." />
 		<script src="https://cdn.usefathom.com/script.js" data-site="GFZYUASY" defer></script>
 		%sveltekit.head%
 	</head>

--- a/src/app.html
+++ b/src/app.html
@@ -8,7 +8,7 @@
 			href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🎞️</text></svg>"
 		/>
 		<title>Hvað er í bíó?</title>
-		<meta name="Hvað er í bíó er fljótlegt yfirlit yfir bíódagskrá kvöldsins á öllu landinu." />
+		<meta description="Hvað er í bíó er fljótlegt yfirlit yfir bíódagskrá kvöldsins á öllu landinu." />
 		<script src="https://cdn.usefathom.com/script.js" data-site="GFZYUASY" defer></script>
 		%sveltekit.head%
 	</head>


### PR DESCRIPTION
Uses Fathom which is a cookie-less, non-ad-fueled, EU-based analytics service. I'll create a public dashboard and post the link here once the connection is set up.  Also adds a mets description to bump the lighthouse SEO score from 92 to 💯