### PR TITLE
fix scroll not being unlocked after closing a modal

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -78,13 +78,11 @@
 			'noscroll',
 			$movie_dialog.expanded || $about_dialog.expanded
 		)
-	let movie_dialog_scroll: HTMLElement
-	let about_dialog_scroll: HTMLElement
 	$: if (browser) {
 		if ($movie_dialog.expanded || $about_dialog.expanded) {
-			lock([movie_dialog_scroll, about_dialog_scroll])
+			lock()
 		} else {
-			unlock([movie_dialog_scroll, about_dialog_scroll])
+			unlock()
 		}
 	}
 
@@ -145,7 +143,6 @@
 	>
 		<div
 			class="relative rounded-2xl bg-neutral-950 m-6 shadow-xl screen-height w-[min(100vw,860px)] overflow-y-auto p-4 sm:p-8 transition-opacity"
-			bind:this={movie_dialog_scroll}
 		>
 			<div use:movie_dialog.modal>
 				{#if movie}
@@ -191,7 +188,6 @@
 	<div class="fixed inset-0 z-50 backdrop-blur-sm flex justify-center items-end sm:items-center">
 		<div
 			class="relative rounded-2xl bg-neutral-950 m-4 shadow-xl screen-height w-[min(100vw,860px)] overflow-y-auto p-4 sm:p-8"
-			bind:this={about_dialog_scroll}
 		>
 			<div use:about_dialog.modal>
 				<h3 class="font-bold mb-2 text-lg md:text-2xl text-neutral-200">Um okkur 🍿</h3>


### PR DESCRIPTION
This is my attempt to fix https://github.com/multivac61/hvaderibio/issues/9 by removing the target element from the lock and unlock methods. I have tested this on Arc on Mac, Chrome on mac and Chrome on Android and it seems to be working fine.

Possibly this will break something as I am not sure why the target element is being passed in to the lock and unlock methods. I noticed the docs for [tua-body-scroll-lock](https://github.com/tuax/tua-body-scroll-lock) mention that the target element is needed in some cases so maybe this breaks some intended behaviour on iOS? I don't have an iPhone to test this on so I haven't had a chance to verify on iOS.

