### PR TITLE
fix: prerender /movie/[id] routes not found by crawler

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -20,5 +20,8 @@ export default {
   preprocess: vitePreprocess(),
   kit: {
     adapter: await getAdapter(),
+    prerender: {
+      handleUnseenRoutes: "prerender",
+    },
   },
 };


### PR DESCRIPTION
## Summary
- SvelteKit build fails because `/movie/[id]` routes are marked prerenderable but the crawler can't find them (home page uses `goto()` not `<a>` tags)
- Add `handleUnseenRoutes: "prerender"` to svelte.config.js so routes with `entries()` are prerendered even without crawler discovery

## Test plan
- [ ] `bun run build` completes without the prerender error
- [ ] `/movie/[id]` pages are correctly prerendered in the build output

🤖 Generated with [Claude Code](https://claude.com/claude-code)