### PR TITLE
fix: trust kvikmyndir TLS intermediate in GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,17 @@ jobs:
       - name: 📚 Install node dependencies
         run: bun install
 
+      - name: 🔐 Trust missing TLS intermediate for kvikmyndir.is
+        run: |
+          openssl s_client -connect www.kvikmyndir.is:443 -servername www.kvikmyndir.is -showcerts </dev/null 2>/dev/null \
+            | awk '/BEGIN CERTIFICATE/{flag=1} flag{print} /END CERTIFICATE/{exit}' > "$RUNNER_TEMP/kvikmyndir-leaf.pem"
+
+          issuer_url=$(openssl x509 -in "$RUNNER_TEMP/kvikmyndir-leaf.pem" -noout -text | awk -F'URI:' '/CA Issuers - URI:/{print $2; exit}')
+          curl -fsSL "$issuer_url" -o "$RUNNER_TEMP/kvikmyndir-issuer.der"
+          openssl x509 -inform DER -in "$RUNNER_TEMP/kvikmyndir-issuer.der" -out "$RUNNER_TEMP/kvikmyndir-issuer.pem"
+
+          echo "NODE_EXTRA_CA_CERTS=$RUNNER_TEMP/kvikmyndir-issuer.pem" >> "$GITHUB_ENV"
+
       - name: 🎬 Scrape movie data
         run: bun scrape
 


### PR DESCRIPTION
## Summary
- work around kvikmyndir.is serving an incomplete TLS chain in CI
- fetch the issuer certificate for the site leaf cert during the workflow
- expose it via NODE_EXTRA_CA_CERTS before running `bun scrape`

## Notes
- keeps TLS verification enabled
- avoids the insecure `NODE_TLS_REJECT_UNAUTHORIZED=0` workaround

## Validation
- `nix fmt -- .github/workflows/deploy.yml`
- `bunx prettier --write .github/workflows/deploy.yml`