### PR TITLE
Refactor shared UI and scraping helpers

### DIFF
--- a/src/lib/CinemaSelect.svelte
+++ b/src/lib/CinemaSelect.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import type { CinemaOption } from "$lib/cinemas";
+
+  type Props = {
+    cinemaOptions: readonly CinemaOption[];
+    selectedChoice: string;
+    onSelect: (choice: string) => void;
+  };
+
+  const { cinemaOptions, selectedChoice, onSelect }: Props = $props();
+
+  const handleChange = (event: Event & { currentTarget: HTMLSelectElement }) => {
+    onSelect(event.currentTarget.value);
+  };
+</script>
+
+<div class="relative">
+  <select
+    value={selectedChoice}
+    onchange={handleChange}
+    id="select-cinemas-mobile"
+    name="select cinemas mobile"
+    aria-label="Veldu kvikmyndahús"
+    class="appearance-none rounded-full border border-white/10 bg-black/70 py-1 pr-8 pl-8 text-center text-sm font-medium text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.1),0_4px_14px_rgba(0,0,0,0.26)] focus:border-sky-300/40 focus:ring-2 focus:ring-sky-300/15 focus:outline-none">
+    {#each cinemaOptions as [label] (label)}
+      <option
+        value={label}
+        id={`option-${label}`}
+        aria-label={label}
+        selected={label === selectedChoice}
+        class="bg-neutral-800 text-center text-white">
+        {label}
+      </option>
+    {/each}
+  </select>
+  <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3">
+    <svg class="h-4 w-4 text-neutral-300/80" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+      <path
+        fill-rule="evenodd"
+        d="M5.23 7.21a.75.75 0 011.06.02L10 10.94l3.71-3.71a.75.75 0 111.06 1.06l-4.25 4.25a.75.75 0 01-1.06 0L5.23 8.29a.75.75 0 01.02-1.06z"
+        clip-rule="evenodd" />
+    </svg>
+  </div>
+</div>

--- a/src/lib/CinemaShowtimeRow.svelte
+++ b/src/lib/CinemaShowtimeRow.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import { CINEMA_URLS } from "$lib/constants";
+  import type { Showtime } from "$lib/schemas";
+  import ShowtimeBadges from "$lib/ShowtimeBadges.svelte";
+
+  type Props = {
+    cinema: string;
+    showtimes: readonly Showtime[];
+  };
+
+  const { cinema, showtimes }: Props = $props();
+  const cinemaUrl = $derived(CINEMA_URLS[cinema]);
+</script>
+
+<div
+  class="rounded-2xl border border-white/[0.06] bg-white/[0.03] p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.06),0_6px_20px_rgba(0,0,0,0.2)] backdrop-blur-xl md:p-4">
+  <div class="mb-2 min-w-0 md:mb-3">
+    {#if cinemaUrl}
+      <a
+        href={cinemaUrl}
+        target="_blank"
+        rel="external noopener noreferrer"
+        class="text-sm font-semibold text-neutral-200 transition-colors hover:text-white hover:underline hover:decoration-neutral-500 hover:underline-offset-4">
+        {cinema}
+      </a>
+    {:else}
+      <span class="text-sm font-semibold text-neutral-200">{cinema}</span>
+    {/if}
+  </div>
+
+  <div class="flex flex-wrap gap-2">
+    {#each showtimes as showtime, i (`${showtime.time}-${i}`)}
+      <a
+        href={showtime.purchase_url}
+        target="_blank"
+        rel="external noopener noreferrer"
+        class="relative rounded bg-neutral-800 px-2 py-1.5 text-sm text-neutral-400 tabular-nums transition-colors hover:bg-neutral-700 hover:text-white">
+        <ShowtimeBadges {showtime} />
+        {new Date(showtime.time).toLocaleTimeString("is-IS", { timeStyle: "short", hour12: false })}
+      </a>
+    {/each}
+  </div>
+</div>

--- a/src/lib/CinemaShowtimeRow.svelte
+++ b/src/lib/CinemaShowtimeRow.svelte
@@ -20,11 +20,11 @@
         href={cinemaUrl}
         target="_blank"
         rel="external noopener noreferrer"
-        class="text-sm font-semibold text-neutral-200 transition-colors hover:text-white hover:underline hover:decoration-neutral-500 hover:underline-offset-4">
+        class="text-sm font-semibold text-neutral-200 transition-colors hover:text-white hover:underline hover:decoration-neutral-500 hover:underline-offset-4 md:text-base">
         {cinema}
       </a>
     {:else}
-      <span class="text-sm font-semibold text-neutral-200">{cinema}</span>
+      <span class="text-sm font-semibold text-neutral-200 md:text-base">{cinema}</span>
     {/if}
   </div>
 
@@ -34,9 +34,10 @@
         href={showtime.purchase_url}
         target="_blank"
         rel="external noopener noreferrer"
-        class="relative rounded bg-neutral-800 px-2 py-1.5 text-sm text-neutral-400 tabular-nums transition-colors hover:bg-neutral-700 hover:text-white">
+        class="group/time relative inline-flex items-center gap-1.5 rounded bg-neutral-800 px-2 py-1.5 text-sm text-neutral-400 tabular-nums transition-colors hover:bg-neutral-700 hover:text-white">
         <ShowtimeBadges {showtime} />
-        {new Date(showtime.time).toLocaleTimeString("is-IS", { timeStyle: "short", hour12: false })}
+        <span>{new Date(showtime.time).toLocaleTimeString("is-IS", { timeStyle: "short", hour12: false })}</span>
+        <span class="hidden text-[10px] font-medium text-neutral-500 group-hover/time:inline group-hover/time:text-neutral-300">Miðar</span>
       </a>
     {/each}
   </div>

--- a/src/lib/CinemaShowtimeRow.svelte
+++ b/src/lib/CinemaShowtimeRow.svelte
@@ -34,10 +34,13 @@
         href={showtime.purchase_url}
         target="_blank"
         rel="external noopener noreferrer"
-        class="group/time relative inline-flex items-center gap-1.5 rounded bg-neutral-800 px-2 py-1.5 text-sm text-neutral-400 tabular-nums transition-colors hover:bg-neutral-700 hover:text-white">
+        class="group/time relative inline-flex items-center rounded bg-neutral-800 px-2 py-1.5 text-sm text-neutral-400 tabular-nums transition-colors hover:bg-neutral-700 hover:text-white">
         <ShowtimeBadges {showtime} />
         <span>{new Date(showtime.time).toLocaleTimeString("is-IS", { timeStyle: "short", hour12: false })}</span>
-        <span class="hidden text-[10px] font-medium text-neutral-500 group-hover/time:inline group-hover/time:text-neutral-300">Miðar</span>
+        <span
+          class="pointer-events-none absolute bottom-full left-1/2 mb-1.5 hidden -translate-x-1/2 rounded bg-neutral-950/95 px-2 py-1 text-[10px] font-medium whitespace-nowrap text-neutral-300 opacity-0 shadow-lg transition-opacity group-hover/time:opacity-100 [@media(hover:hover)]:block">
+          Kaupa miða
+        </span>
       </a>
     {/each}
   </div>

--- a/src/lib/CinemaTabs.svelte
+++ b/src/lib/CinemaTabs.svelte
@@ -18,8 +18,8 @@
       class={`shrink-0 rounded-xl border px-3.5 py-1.5 text-[15px] leading-5 font-medium whitespace-nowrap transition-all duration-200 ease-out focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-900
                     ${
                       label === selectedChoice
-                        ? "border-sky-300/50 bg-neutral-950 text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.18),0_0_0_1px_rgba(125,211,252,0.28),0_0_18px_rgba(56,189,248,0.14),0_8px_24px_rgba(0,0,0,0.35)]"
-                        : "border-transparent bg-neutral-800/60 text-neutral-400 hover:bg-neutral-900 hover:text-neutral-200"
+                        ? "border-sky-300/35 bg-neutral-950/80 text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.14),0_6px_18px_rgba(0,0,0,0.28)]"
+                        : "border-transparent bg-neutral-900/50 text-neutral-500 hover:bg-neutral-900/80 hover:text-neutral-200"
                     }
                   `}>
       {label}

--- a/src/lib/CinemaTabs.svelte
+++ b/src/lib/CinemaTabs.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import type { CinemaOption } from "$lib/cinemas";
+
+  type Props = {
+    cinemaOptions: readonly CinemaOption[];
+    selectedChoice: string;
+    onSelect: (choice: string) => void;
+  };
+
+  const { cinemaOptions, selectedChoice, onSelect }: Props = $props();
+</script>
+
+<div class="mb-3 flex flex-nowrap justify-center gap-1.5 overflow-x-auto px-2 md:gap-2">
+  {#each cinemaOptions as [label] (label)}
+    <button
+      type="button"
+      onclick={() => onSelect(label)}
+      class={`shrink-0 rounded-xl border px-3.5 py-1.5 text-[15px] leading-5 font-medium whitespace-nowrap transition-all duration-200 ease-out focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-900
+                    ${
+                      label === selectedChoice
+                        ? "border-sky-300/50 bg-neutral-950 text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.18),0_0_0_1px_rgba(125,211,252,0.28),0_0_18px_rgba(56,189,248,0.14),0_8px_24px_rgba(0,0,0,0.35)]"
+                        : "border-transparent bg-neutral-800/60 text-neutral-400 hover:bg-neutral-900 hover:text-neutral-200"
+                    }
+                  `}>
+      {label}
+    </button>
+  {/each}
+</div>

--- a/src/lib/MoviePosterCard.svelte
+++ b/src/lib/MoviePosterCard.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  import { goto } from "$app/navigation";
+  import { resolve } from "$app/paths";
+
+  import type { Movie } from "$lib/schemas";
+
+  type Props = {
+    movie: Movie;
+    index: number;
+  };
+
+  const { movie, index }: Props = $props();
+  const movieHref = $derived(resolve(`/movie/${movie.id}`));
+
+  let touchStartY = 0;
+
+  const handleTouchStart = (event: TouchEvent) => {
+    touchStartY = event.touches[0].clientY;
+  };
+
+  const handleTouchEnd = (event: TouchEvent) => {
+    const touchEndY = event.changedTouches[0].clientY;
+    if (Math.abs(touchEndY - touchStartY) < 10) {
+      event.preventDefault();
+      // eslint-disable-next-line svelte/no-navigation-without-resolve
+      goto(movieHref);
+    }
+  };
+</script>
+
+<!-- eslint-disable svelte/no-navigation-without-resolve -->
+<a
+  href={movieHref}
+  data-movie-id={movie.id}
+  ontouchstart={handleTouchStart}
+  ontouchend={handleTouchEnd}
+  class="group block aspect-2/3 w-full touch-manipulation overflow-visible rounded-lg bg-neutral-900 [@media(hover:hover)]:hover:z-50"
+  style="-webkit-tap-highlight-color: transparent; touch-action: manipulation; user-select: none; -webkit-user-select: none;">
+  <picture>
+    <source
+      type="image/webp"
+      srcset="/{movie.id}-360w.webp 360w, /{movie.id}.webp 720w, /{movie.id}-1080w.webp 1080w"
+      sizes="(max-width: 640px) calc(50vw - 2rem), 360px" />
+    <img
+      src="/{movie.id}.webp"
+      alt={movie.title}
+      title={movie.title}
+      fetchpriority={index < 4 ? "high" : "auto"}
+      loading="eager"
+      decoding="async"
+      width="720"
+      height="1080"
+      style:view-transition-name="poster-{movie.id}"
+      class="shadow-5xl pointer-events-none h-full w-full rounded-lg object-fill [@media(hover:hover)]:transition-transform [@media(hover:hover)]:duration-300 [@media(hover:hover)]:ease-out [@media(hover:hover)]:group-hover:scale-[1.02]" />
+  </picture>
+</a>

--- a/src/lib/MovieRatings.svelte
+++ b/src/lib/MovieRatings.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+  import type { Movie } from "$lib/schemas";
+
+  type Props = {
+    movie: Movie;
+    desktop?: boolean;
+  };
+
+  const { movie, desktop = false }: Props = $props();
+  const linkClass = $derived(
+    desktop
+      ? "hidden items-center gap-1 text-neutral-500 hover:text-white md:inline-flex"
+      : "inline-flex items-center gap-1 text-neutral-500 hover:text-white"
+  );
+</script>
+
+{#if movie.imdb?.star}
+  {#if desktop}<span class="hidden md:inline">·</span>{/if}
+  <a href={movie.imdb.link} target="_blank" rel="external noopener noreferrer" class={linkClass}>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 32" width="28" height="14" class="fill-[#F5C518]">
+      <rect rx="3" width="64" height="32" />
+      <text x="32" y="22" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="#000">IMDb</text>
+    </svg>
+    <span>{movie.imdb.star}</span>
+  </a>
+{/if}
+
+{#if movie.rotten_tomatoes}
+  {#if desktop}<span class="hidden md:inline">·</span>{/if}
+  <a
+    href={movie.rotten_tomatoes.url ?? `https://www.rottentomatoes.com/search?search=${encodeURIComponent(movie.alt_title || movie.title)}`}
+    target="_blank"
+    rel="external noopener noreferrer"
+    class={linkClass}>
+    <img src="/rotten-tomatoes.svg" alt="RT" width="14" height="14" />
+    <span>{movie.rotten_tomatoes.score}%</span>
+    {#if !desktop && movie.rotten_tomatoes.audience_score}
+      <span class="text-neutral-600">({movie.rotten_tomatoes.audience_score}%)</span>
+    {/if}
+  </a>
+{/if}
+
+{#if movie.metacritic}
+  {#if desktop}<span class="hidden md:inline">·</span>{/if}
+  <a
+    href={movie.metacritic.url ?? `https://www.metacritic.com/search/${encodeURIComponent(movie.alt_title || movie.title)}/`}
+    target="_blank"
+    rel="external noopener noreferrer"
+    class={linkClass}>
+    <img src="/metacritic.svg" alt="MC" width="14" height="14" />
+    <span>{movie.metacritic.score}</span>
+    {#if !desktop && movie.metacritic.user_score}
+      <span class="text-neutral-600">({movie.metacritic.user_score})</span>
+    {/if}
+  </a>
+{/if}
+
+{#if movie.letterboxd?.score}
+  {#if desktop}<span class="hidden md:inline">·</span>{/if}
+  <a
+    href={movie.letterboxd.url ?? `https://letterboxd.com/search/${encodeURIComponent(movie.alt_title || movie.title)}/`}
+    target="_blank"
+    rel="external noopener noreferrer"
+    class={linkClass}>
+    <img src="/letterboxd.svg" alt="LB" width="14" height="14" />
+    <span>{movie.letterboxd.score}</span>
+  </a>
+{/if}

--- a/src/lib/ShowtimeBadges.svelte
+++ b/src/lib/ShowtimeBadges.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+  import type { Showtime } from "$lib/schemas";
+
+  type Props = {
+    showtime: Showtime;
+  };
+
+  const { showtime }: Props = $props();
+
+  const hasBadges = $derived(
+    showtime.is_icelandic ||
+      showtime.is_3d ||
+      showtime.is_luxus ||
+      showtime.is_vip ||
+      showtime.is_atmos ||
+      showtime.is_max ||
+      showtime.is_flauel
+  );
+</script>
+
+{#if hasBadges}
+  <span class="absolute -top-1.5 -right-1.5 flex gap-0.5">
+    {#if showtime.is_icelandic}
+      <svg class="h-2.5 w-3" viewBox="0 0 25 18" fill="none">
+        <rect width="25" height="18" fill="#003897" />
+        <rect x="7" width="4" height="18" fill="#fff" />
+        <rect y="7" width="25" height="4" fill="#fff" />
+        <rect x="8" width="2" height="18" fill="#D72828" />
+        <rect y="8" width="25" height="2" fill="#D72828" />
+      </svg>
+    {/if}
+    {#if showtime.is_3d}
+      <span class="rounded bg-blue-600 px-0.5 text-[8px] font-bold text-white">3D</span>
+    {/if}
+    {#if showtime.is_luxus}
+      <span class="rounded bg-yellow-500 px-0.5 text-[8px] font-bold text-black">LÚX</span>
+    {/if}
+    {#if showtime.is_vip}
+      <span class="rounded bg-emerald-600 px-0.5 text-[8px] font-bold text-white">VIP</span>
+    {/if}
+    {#if showtime.is_atmos}
+      <span class="rounded bg-purple-600 px-0.5 text-[8px] font-bold text-white">ÁSBERG</span>
+    {/if}
+    {#if showtime.is_max}
+      <span class="rounded bg-red-600 px-0.5 text-[8px] font-bold text-white">MAX</span>
+    {/if}
+    {#if showtime.is_flauel}
+      <span class="rounded bg-pink-500 px-0.5 text-[8px] font-bold text-white">FLAUEL</span>
+    {/if}
+  </span>
+{/if}

--- a/src/lib/cinemas.ts
+++ b/src/lib/cinemas.ts
@@ -1,0 +1,21 @@
+import { CAPITAL_REGION_CINEMAS } from "$lib/constants";
+import type { Movie } from "$lib/schemas";
+
+export type CinemaOption = readonly [string, readonly string[]];
+
+export const get_all_cinemas = (movies: readonly Movie[]) =>
+  movies
+    .flatMap((movie) => Object.values(movie.showtimes_by_day).flatMap((day) => Object.keys(day)))
+    .filter((name, index, array) => array.indexOf(name) === index)
+    .sort();
+
+export const get_cinema_options = (movies: readonly Movie[]): readonly CinemaOption[] => {
+  const all_cinemas = get_all_cinemas(movies);
+  const capital_region_cinemas = all_cinemas.filter((name) => (CAPITAL_REGION_CINEMAS as readonly string[]).includes(name));
+
+  return [
+    ["Öll kvikmyndahús", all_cinemas],
+    ["Höfuðborgarsvæðið", capital_region_cinemas],
+    ...all_cinemas.map((name) => [name, [name]] as const),
+  ] as const;
+};

--- a/src/lib/parse.ts
+++ b/src/lib/parse.ts
@@ -83,7 +83,7 @@ export function parse_movie(document: Document, id: number) {
   }
 
   // Ratings from hero section
-  let imdb: { link: string; star: number } | undefined;
+  let imdb: { link: string; star?: number } | undefined;
   let rotten_tomatoes: { score: number } | undefined;
   let metacritic: { score: number } | undefined;
 
@@ -95,17 +95,17 @@ export function parse_movie(document: Document, id: number) {
 
     if (img?.alt?.toLowerCase().includes("imdb")) {
       const star = parseFloat(scoreText);
-      if (!isNaN(star) && link) {
-        imdb = { link, star };
+      if (link) {
+        imdb = Number.isFinite(star) && star > 0 ? { link, star } : { link };
       }
     } else if (img?.alt?.toLowerCase().includes("rotten")) {
       const score = parseInt(scoreText.replace("%", ""));
-      if (!isNaN(score)) {
+      if (Number.isFinite(score) && score > 0) {
         rotten_tomatoes = { score };
       }
     } else if (img?.alt?.toLowerCase().includes("metacritic")) {
       const score = parseInt(scoreText);
-      if (!isNaN(score)) {
+      if (Number.isFinite(score) && score > 0) {
         metacritic = { score };
       }
     }
@@ -115,7 +115,7 @@ export function parse_movie(document: Document, id: number) {
   if (!imdb) {
     const imdbLink = document.querySelector<HTMLAnchorElement>("a.mp-external-links__item[href*='imdb.com']");
     if (imdbLink) {
-      imdb = { link: imdbLink.href, star: 0 };
+      imdb = { link: imdbLink.href };
     }
   }
 
@@ -340,6 +340,43 @@ export function parse_hall_info_from_listing(document: Document): Map<string, Ha
   });
 
   return hallInfoMap;
+}
+
+export type ImdbRating = { star: number; votes: number };
+
+// Fetch IMDb ratings from IMDb's public dataset. This avoids relying on the
+// kvikmyndir.is rating widget, which can be stale or missing and previously
+// caused us to persist placeholder 0 ratings from IMDb links.
+export async function fetch_imdb_ratings(imdbIds: readonly string[]): Promise<Map<string, ImdbRating>> {
+  const ids = new Set(imdbIds);
+  const ratings = new Map<string, ImdbRating>();
+  if (ids.size === 0) return ratings;
+
+  const response = await fetch("https://datasets.imdbws.com/title.ratings.tsv.gz", {
+    headers: { "User-Agent": "hvaderibio/1.0" },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch IMDb ratings dataset: ${response.status} ${response.statusText}`);
+  }
+
+  const { gunzipSync } = await import("node:zlib");
+  const tsv = gunzipSync(Buffer.from(await response.arrayBuffer())).toString("utf8");
+
+  for (const line of tsv.split("\n").slice(1)) {
+    if (ratings.size === ids.size) break;
+
+    const [id, averageRating, numVotes] = line.split("\t");
+    if (!ids.has(id)) continue;
+
+    const star = parseFloat(averageRating);
+    const votes = parseInt(numVotes);
+    if (Number.isFinite(star) && star > 0 && Number.isFinite(votes)) {
+      ratings.set(id, { star, votes });
+    }
+  }
+
+  return ratings;
 }
 
 // Fetch RT, Metacritic, and Letterboxd URLs from Wikidata using IMDb ID

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -40,7 +40,7 @@ export const movie_schema = z.object({
   imdb: z.optional(
     z.object({
       link: z.url(),
-      star: z.number(),
+      star: z.optional(z.number()),
     })
   ),
   rotten_tomatoes: z.optional(

--- a/src/lib/showtimes.ts
+++ b/src/lib/showtimes.ts
@@ -1,0 +1,29 @@
+import type { Movie, Showtime } from "$lib/schemas";
+import { in_range, to_float } from "$lib/util";
+
+export const get_showtime_window = () => ({
+  from: Math.min(21, new Date().getHours()),
+  to: 24,
+});
+
+export const is_valid_showtime = (showtime: Showtime, selected_day: string, from: number, to: number) => {
+  if (selected_day !== "0") return true;
+  return Boolean(showtime.time && in_range(to_float(showtime.time), from, to));
+};
+
+export const get_valid_showtimes = (showtimes: readonly Showtime[], selected_day: string, from: number, to: number) =>
+  showtimes.filter((showtime) => is_valid_showtime(showtime, selected_day, from, to));
+
+export const count_movie_showtimes = (
+  movie: Movie,
+  selected_day: string,
+  selected_cinemas: readonly string[],
+  from: number,
+  to: number
+) => {
+  const day_showtimes = movie.showtimes_by_day[selected_day] ?? {};
+
+  return Object.entries(day_showtimes)
+    .filter(([cinema]) => selected_cinemas.includes(cinema))
+    .reduce((total, [, showtimes]) => total + get_valid_showtimes(showtimes, selected_day, from, to).length, 0);
+};

--- a/src/lib/video.ts
+++ b/src/lib/video.ts
@@ -1,0 +1,3 @@
+export const get_youtube_id = (url: string | undefined) => url?.match(/(?:v=|\/vi\/)([^&?/]+)/)?.[1];
+
+export const is_mobile_user_agent = () => /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,21 +1,10 @@
+import { get_cinema_options } from "$lib/cinemas";
 import { readMovies } from "$lib/movies";
-import { CAPITAL_REGION_CINEMAS } from "$lib/constants";
 
 export const load = async () => {
   const { movies } = await readMovies();
 
-  const all_cinemas = movies
-    .flatMap((movie) => Object.values(movie.showtimes_by_day).flatMap((day) => Object.keys(day)))
-    .filter((name, index, array) => array.indexOf(name) === index)
-    .sort();
-
-  const capital_region_cinemas = all_cinemas.filter((name) => (CAPITAL_REGION_CINEMAS as readonly string[]).includes(name));
-
-  const cinema_options = [
-    ["Öll kvikmyndahús", all_cinemas],
-    ["Höfuðborgarsvæðið", capital_region_cinemas],
-    ...all_cinemas.map((name) => [name, [name]] as const),
-  ] as const;
+  const cinema_options = get_cinema_options(movies);
 
   return {
     movies,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,42 +1,17 @@
 <script lang="ts">
-  import { resolve } from "$app/paths";
-  import { goto } from "$app/navigation";
-
-  import { in_range, to_float } from "$lib/util";
-  import type { Movie, Showtime } from "$lib/schemas";
+  import { count_movie_showtimes, get_showtime_window } from "$lib/showtimes";
   import { DEFAULT_CINEMA_CHOICE, get_cinemas_for_choice, cinemaState } from "$lib/cinema-state.svelte";
   import { dayState } from "$lib/day-state.svelte";
+  import CinemaSelect from "$lib/CinemaSelect.svelte";
+  import CinemaTabs from "$lib/CinemaTabs.svelte";
   import DayPicker from "$lib/DayPicker.svelte";
+  import MoviePosterCard from "$lib/MoviePosterCard.svelte";
 
   const { data } = $props();
   const movies = $derived(data.movies);
   const cinema_options = $derived(data.cinema_options);
 
-  // Handle touch events to bypass iOS Safari tap issues
-  let touchStartY = 0;
-
-  const createTouchHandlers = (href: string) => ({
-    handleTouchStart: (e: TouchEvent) => {
-      touchStartY = e.touches[0].clientY;
-    },
-    handleTouchEnd: (e: TouchEvent) => {
-      // Only navigate if it wasn't a scroll (touch moved less than 10px)
-      const touchEndY = e.changedTouches[0].clientY;
-      if (Math.abs(touchEndY - touchStartY) < 10) {
-        e.preventDefault();
-        // @ts-expect-error - Dynamic route navigation
-        goto(resolve(href));
-      }
-    },
-    handleClick: () => {
-      // Fallback for non-touch devices
-      // @ts-expect-error - Dynamic route navigation
-      goto(resolve(href));
-    },
-  });
-
-  const to = $state(24);
-  const from = $derived(Math.min(21, new Date().getHours()));
+  const { from, to } = get_showtime_window();
 
   // Read cinema and day from shared state
   const selected_choice = $derived(cinemaState.value ?? DEFAULT_CINEMA_CHOICE);
@@ -51,41 +26,14 @@
     dayState.set(day);
   };
 
-  const handleSelectChange = (event: Event & { currentTarget: HTMLSelectElement }) => {
-    updateCinema(event.currentTarget.value);
-  };
-
-  let filtered_cinemas_showtimes = $derived(
+  const filtered_cinemas_showtimes = $derived.by(() =>
     movies
-      .filter((movie) => {
-        const day_showtimes = movie.showtimes_by_day[selected_day] ?? {};
-        const totalValidShowtimes = Object.entries(day_showtimes)
-          .filter(([cinema]) => selected_cinemas.includes(cinema))
-          .reduce((total, [, times]) => {
-            // Only filter by time for today
-            if (selected_day === "0") {
-              const validTimes = (times as Showtime[]).filter(({ time }) => time && in_range(to_float(time), from, to));
-              return total + validTimes.length;
-            }
-            return total + (times as Showtime[]).length;
-          }, 0);
-        return totalValidShowtimes > 0;
-      })
-      .sort((a, b) => {
-        const getTotalValidShowtimes = (movie: Movie) => {
-          const day_showtimes = movie.showtimes_by_day[selected_day] ?? {};
-          return Object.entries(day_showtimes)
-            .filter(([cinema]) => selected_cinemas.includes(cinema))
-            .reduce((total, [, times]) => {
-              if (selected_day === "0") {
-                const validTimes = (times as Showtime[]).filter(({ time }) => time && in_range(to_float(time), from, to));
-                return total + validTimes.length;
-              }
-              return total + (times as Showtime[]).length;
-            }, 0);
-        };
-        return getTotalValidShowtimes(b) - getTotalValidShowtimes(a);
-      })
+      .filter((movie) => count_movie_showtimes(movie, selected_day, selected_cinemas, from, to) > 0)
+      .sort(
+        (a, b) =>
+          count_movie_showtimes(b, selected_day, selected_cinemas, from, to) -
+          count_movie_showtimes(a, selected_day, selected_cinemas, from, to)
+      )
   );
 </script>
 
@@ -100,22 +48,7 @@
   </h1>
   <div class="mx-auto sm:block md:max-w-none">
     <!-- Cinema selection -->
-    <div class="mb-3 flex flex-nowrap justify-center gap-1.5 overflow-x-auto px-2 md:gap-2">
-      {#each cinema_options as [label] (label)}
-        <button
-          type="button"
-          onclick={() => updateCinema(label)}
-          class={`shrink-0 rounded-xl border px-3.5 py-1.5 text-[15px] leading-5 font-medium whitespace-nowrap transition-all duration-200 ease-out focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-900
-                    ${
-                      label === selected_choice
-                        ? "border-sky-300/50 bg-neutral-950 text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.18),0_0_0_1px_rgba(125,211,252,0.28),0_0_18px_rgba(56,189,248,0.14),0_8px_24px_rgba(0,0,0,0.35)]"
-                        : "border-transparent bg-neutral-800/60 text-neutral-400 hover:bg-neutral-900 hover:text-neutral-200"
-                    }
-                  `}>
-          {label}
-        </button>
-      {/each}
-    </div>
+    <CinemaTabs cinemaOptions={cinema_options} selectedChoice={selected_choice} onSelect={updateCinema} />
     <!-- Day selection -->
     <div class="flex justify-center">
       <DayPicker {selected_day} onSelect={updateDay} />
@@ -128,39 +61,7 @@
     <div class="flex flex-col items-center gap-2">
       <!-- Cinema dropdown -->
       <div class="flex justify-center">
-        <div class="relative">
-          <select
-            value={selected_choice}
-            onchange={handleSelectChange}
-            id="select-cinemas-mobile"
-            name="select cinemas mobile"
-            aria-label="Veldu kvikmyndahús"
-            class="appearance-none rounded-full border border-white/10 bg-black/70 py-1 pr-8 pl-8 text-center text-sm font-medium text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.1),0_4px_14px_rgba(0,0,0,0.26)] focus:border-sky-300/40 focus:ring-2 focus:ring-sky-300/15 focus:outline-none">
-            {#each cinema_options as [label] (label)}
-              <option
-                value={label}
-                id={`option-${label}`}
-                aria-label={label}
-                selected={label === selected_choice}
-                class="bg-neutral-800 text-center text-white">
-                {label}
-              </option>
-            {/each}
-          </select>
-          <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3">
-            <svg
-              class="h-4 w-4 text-neutral-300/80"
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-              aria-hidden="true">
-              <path
-                fill-rule="evenodd"
-                d="M5.23 7.21a.75.75 0 011.06.02L10 10.94l3.71-3.71a.75.75 0 111.06 1.06l-4.25 4.25a.75.75 0 01-1.06 0L5.23 8.29a.75.75 0 01.02-1.06z"
-                clip-rule="evenodd" />
-            </svg>
-          </div>
-        </div>
+        <CinemaSelect cinemaOptions={cinema_options} selectedChoice={selected_choice} onSelect={updateCinema} />
       </div>
       <!-- Day pills -->
       <div class="flex justify-center">
@@ -179,35 +80,7 @@
   <div
     class="md:md-30 -mx-1 mb-24 grid grid-cols-[repeat(auto-fill,minmax(min(9rem,100%),2fr))] gap-4 sm:mx-0 sm:mb-8 sm:grid-cols-[repeat(auto-fill,minmax(min(20rem,100%),2fr))] sm:gap-6 sm:pt-2">
     {#each filtered_cinemas_showtimes as movie, index (movie.id)}
-      {@const handlers = createTouchHandlers(`/movie/${movie.id}`)}
-      <div
-        role="button"
-        tabindex="0"
-        data-movie-id={movie.id}
-        ontouchstart={handlers.handleTouchStart}
-        ontouchend={handlers.handleTouchEnd}
-        onclick={handlers.handleClick}
-        onkeydown={(e) => (e.key === "Enter" || e.key === " ") && handlers.handleClick()}
-        class="group block aspect-2/3 w-full touch-manipulation overflow-visible rounded-lg bg-neutral-900 [@media(hover:hover)]:hover:z-50"
-        style="cursor: pointer; -webkit-tap-highlight-color: transparent; touch-action: manipulation; user-select: none; -webkit-user-select: none;">
-        <picture>
-          <source
-            type="image/webp"
-            srcset="/{movie.id}-360w.webp 360w, /{movie.id}.webp 720w, /{movie.id}-1080w.webp 1080w"
-            sizes="(max-width: 640px) calc(50vw - 2rem), 360px" />
-          <img
-            src="/{movie.id}.webp"
-            alt={movie.title}
-            title={movie.title}
-            fetchpriority={index < 4 ? "high" : "auto"}
-            loading="eager"
-            decoding="async"
-            width="720"
-            height="1080"
-            style:view-transition-name="poster-{movie.id}"
-            class="shadow-5xl pointer-events-none h-full w-full rounded-lg object-fill [@media(hover:hover)]:transition-transform [@media(hover:hover)]:duration-300 [@media(hover:hover)]:ease-out [@media(hover:hover)]:group-hover:scale-[1.02]" />
-        </picture>
-      </div>
+      <MoviePosterCard {movie} {index} />
     {/each}
   </div>
 {/if}

--- a/src/routes/movie/[id]/+page.server.ts
+++ b/src/routes/movie/[id]/+page.server.ts
@@ -1,6 +1,6 @@
 import { error } from "@sveltejs/kit";
+import { get_cinema_options } from "$lib/cinemas";
 import { readMovies } from "$lib/movies";
-import { CAPITAL_REGION_CINEMAS } from "$lib/constants";
 import type { PageServerLoad } from "./$types";
 
 // The prerenderer can't find the /movie/[id] routes because it needs the entries() function to know which routes to prerender.
@@ -17,18 +17,7 @@ export const load: PageServerLoad = async ({ params }) => {
     error(404, "Movie not found");
   }
 
-  const all_cinemas = movies
-    .flatMap((movie) => Object.values(movie.showtimes_by_day).flatMap((day) => Object.keys(day)))
-    .filter((name, index, array) => array.indexOf(name) === index)
-    .sort();
-
-  const capital_region_cinemas = all_cinemas.filter((name) => (CAPITAL_REGION_CINEMAS as readonly string[]).includes(name));
-
-  const cinema_options = [
-    ["Öll kvikmyndahús", all_cinemas],
-    ["Höfuðborgarsvæðið", capital_region_cinemas],
-    ...all_cinemas.map((name) => [name, [name]] as const),
-  ] as const;
+  const cinema_options = get_cinema_options(movies);
 
   return {
     movie,

--- a/src/routes/movie/[id]/+page.svelte
+++ b/src/routes/movie/[id]/+page.svelte
@@ -1,19 +1,20 @@
 <script lang="ts">
-  import { in_range, to_float } from "$lib/util";
+  import { get_showtime_window, get_valid_showtimes } from "$lib/showtimes";
+  import { get_youtube_id, is_mobile_user_agent } from "$lib/video";
   import { DEFAULT_CINEMA_CHOICE, get_cinemas_for_choice, cinemaState } from "$lib/cinema-state.svelte";
-  import { CINEMA_URLS } from "$lib/constants";
   import { dayState } from "$lib/day-state.svelte";
   import DayPicker from "$lib/DayPicker.svelte";
+  import MovieRatings from "$lib/MovieRatings.svelte";
+  import CinemaShowtimeRow from "$lib/CinemaShowtimeRow.svelte";
 
   const { data } = $props();
   const movie = $derived(data.movie);
   const cinema_options = $derived(data.cinema_options);
 
   // Extract YouTube video ID from trailer URL
-  const youtube_id = $derived(movie.trailer_url?.match(/(?:v=|\/vi\/)([^&?/]+)/)?.[1]);
+  const youtube_id = $derived(get_youtube_id(movie.trailer_url));
 
-  const to = 24;
-  const from = Math.min(21, new Date().getHours());
+  const { from, to } = get_showtime_window();
 
   // Read cinema from shared state
   const selected_choice = $derived(cinemaState.value ?? DEFAULT_CINEMA_CHOICE);
@@ -24,8 +25,7 @@
   let trailer_modal_open = $state(false);
   const openTrailer = () => {
     // On mobile, open YouTube directly (autoplay doesn't work in iframe)
-    const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
-    if (isMobile && youtube_id) {
+    if (is_mobile_user_agent() && youtube_id) {
       window.open(`https://www.youtube.com/watch?v=${youtube_id}`, "_blank");
     } else {
       trailer_modal_open = true;
@@ -132,113 +132,14 @@
             <span>·</span>
             <span>{movie.genres.slice(0, 2).join(", ")}</span>
           {/if}
-          <!-- Ratings inline on desktop -->
           <!-- eslint-disable svelte/no-navigation-without-resolve -->
-          {#if movie.imdb}
-            <span class="hidden md:inline">·</span>
-            <a
-              href={movie.imdb.link}
-              target="_blank"
-              rel="external noopener noreferrer"
-              class="hidden items-center gap-1 text-neutral-500 hover:text-white md:inline-flex">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 32" width="28" height="14" class="fill-[#F5C518]">
-                <rect rx="3" width="64" height="32" />
-                <text x="32" y="22" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="#000"
-                  >IMDb</text>
-              </svg>
-              <span>{movie.imdb.star}</span>
-            </a>
-          {/if}
-          {#if movie.rotten_tomatoes}
-            <span class="hidden md:inline">·</span>
-            <a
-              href={movie.rotten_tomatoes.url ??
-                `https://www.rottentomatoes.com/search?search=${encodeURIComponent(movie.alt_title || movie.title)}`}
-              target="_blank"
-              rel="external noopener noreferrer"
-              class="hidden items-center gap-1 text-neutral-500 hover:text-white md:inline-flex">
-              <img src="/rotten-tomatoes.svg" alt="RT" width="14" height="14" />
-              <span>{movie.rotten_tomatoes.score}%</span>
-            </a>
-          {/if}
-          {#if movie.metacritic}
-            <span class="hidden md:inline">·</span>
-            <a
-              href={movie.metacritic.url ?? `https://www.metacritic.com/search/${encodeURIComponent(movie.alt_title || movie.title)}/`}
-              target="_blank"
-              rel="external noopener noreferrer"
-              class="hidden items-center gap-1 text-neutral-500 hover:text-white md:inline-flex">
-              <img src="/metacritic.svg" alt="MC" width="14" height="14" />
-              <span>{movie.metacritic.score}</span>
-            </a>
-          {/if}
-          {#if movie.letterboxd?.score}
-            <span class="hidden md:inline">·</span>
-            <a
-              href={movie.letterboxd.url ?? `https://letterboxd.com/search/${encodeURIComponent(movie.alt_title || movie.title)}/`}
-              target="_blank"
-              rel="external noopener noreferrer"
-              class="hidden items-center gap-1 text-neutral-500 hover:text-white md:inline-flex">
-              <img src="/letterboxd.svg" alt="LB" width="14" height="14" />
-              <span>{movie.letterboxd.score}</span>
-            </a>
-          {/if}
+          <MovieRatings {movie} desktop />
         </div>
 
         <!-- Ratings row - mobile only -->
-        {#if movie.imdb || movie.rotten_tomatoes || movie.metacritic || movie.letterboxd}
+        {#if movie.imdb?.star || movie.rotten_tomatoes || movie.metacritic || movie.letterboxd?.score}
           <div class="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-neutral-500 md:hidden">
-            {#if movie.imdb}
-              <a
-                href={movie.imdb.link}
-                target="_blank"
-                rel="external noopener noreferrer"
-                class="inline-flex items-center gap-1 text-neutral-500 hover:text-white">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 32" width="28" height="14" class="fill-[#F5C518]">
-                  <rect rx="3" width="64" height="32" />
-                  <text x="32" y="22" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="#000"
-                    >IMDb</text>
-                </svg>
-                <span>{movie.imdb.star}</span>
-              </a>
-            {/if}
-            {#if movie.rotten_tomatoes}
-              <a
-                href={movie.rotten_tomatoes.url ??
-                  `https://www.rottentomatoes.com/search?search=${encodeURIComponent(movie.alt_title || movie.title)}`}
-                target="_blank"
-                rel="external noopener noreferrer"
-                class="inline-flex items-center gap-1 text-neutral-500 hover:text-white">
-                <img src="/rotten-tomatoes.svg" alt="RT" width="14" height="14" />
-                <span>{movie.rotten_tomatoes.score}%</span>
-                {#if movie.rotten_tomatoes.audience_score}
-                  <span class="text-neutral-600">({movie.rotten_tomatoes.audience_score}%)</span>
-                {/if}
-              </a>
-            {/if}
-            {#if movie.metacritic}
-              <a
-                href={movie.metacritic.url ?? `https://www.metacritic.com/search/${encodeURIComponent(movie.alt_title || movie.title)}/`}
-                target="_blank"
-                rel="external noopener noreferrer"
-                class="inline-flex items-center gap-1 text-neutral-500 hover:text-white">
-                <img src="/metacritic.svg" alt="MC" width="14" height="14" />
-                <span>{movie.metacritic.score}</span>
-                {#if movie.metacritic.user_score}
-                  <span class="text-neutral-600">({movie.metacritic.user_score})</span>
-                {/if}
-              </a>
-            {/if}
-            {#if movie.letterboxd?.score}
-              <a
-                href={movie.letterboxd.url ?? `https://letterboxd.com/search/${encodeURIComponent(movie.alt_title || movie.title)}/`}
-                target="_blank"
-                rel="external noopener noreferrer"
-                class="inline-flex items-center gap-1 text-neutral-500 hover:text-white">
-                <img src="/letterboxd.svg" alt="LB" width="14" height="14" />
-                <span>{movie.letterboxd.score}</span>
-              </a>
-            {/if}
+            <MovieRatings {movie} />
           </div>
         {/if}
       </div>
@@ -276,9 +177,9 @@
             <button
               type="button"
               onclick={() => cinemaState.set(DEFAULT_CINEMA_CHOICE)}
-              class="inline-flex items-center gap-1.5 rounded-full bg-neutral-800 py-1 pr-1.5 pl-3 text-xs font-medium text-neutral-300 transition-colors hover:bg-neutral-700 hover:text-white">
+              class="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-white/[0.06] py-1 pr-1.5 pl-3 text-xs font-medium text-neutral-300 shadow-[inset_0_1px_0_rgba(255,255,255,0.08)] backdrop-blur-xl transition-colors hover:bg-white/10 hover:text-white">
               <span class="max-w-[120px] truncate">{selected_choice}</span>
-              <span class="flex h-4 w-4 items-center justify-center rounded-full bg-neutral-600 transition-colors hover:bg-neutral-500">
+              <span class="flex h-4 w-4 items-center justify-center rounded-full bg-white/15 transition-colors hover:bg-white/25">
                 <svg class="h-2.5 w-2.5 text-neutral-200" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
                 </svg>
@@ -288,65 +189,12 @@
         </div>
 
         <!-- eslint-disable svelte/no-navigation-without-resolve -->
-        <div class="space-y-5">
+        <div class="space-y-3 md:max-w-3xl">
           {#each Object.entries(current_showtimes) as [cinema, times] (cinema)}
             {#if selected_cinemas.includes(cinema)}
-              {@const validTimes = selected_day === "0" ? times.filter(({ time }) => time && in_range(to_float(time), from, to)) : times}
+              {@const validTimes = get_valid_showtimes(times, selected_day, from, to)}
               {#if validTimes.length > 0}
-                <div class="flex flex-col gap-1.5 md:grid md:grid-cols-[auto_1fr] md:items-baseline md:gap-x-3 md:gap-y-0">
-                  {#if CINEMA_URLS[cinema]}
-                    <a
-                      href={CINEMA_URLS[cinema]}
-                      target="_blank"
-                      rel="external noopener noreferrer"
-                      class="text-sm font-medium text-neutral-300 underline decoration-neutral-600 underline-offset-2 transition-colors hover:text-white hover:decoration-neutral-400"
-                      >{cinema}</a>
-                  {:else}
-                    <span class="text-sm font-medium text-neutral-300">{cinema}</span>
-                  {/if}
-                  <div class="flex flex-wrap gap-2">
-                    {#each validTimes as { time, purchase_url, is_icelandic, is_3d, is_luxus, is_vip, is_atmos, is_max, is_flauel }, i (`${time}-${i}`)}
-                      <a
-                        href={purchase_url}
-                        target="_blank"
-                        rel="external noopener noreferrer"
-                        class="relative rounded bg-neutral-800 px-2 py-1.5 text-sm text-neutral-400 tabular-nums transition-colors hover:bg-neutral-700 hover:text-white">
-                        {#if is_icelandic || is_3d || is_luxus || is_vip || is_atmos || is_max || is_flauel}
-                          <span class="absolute -top-1.5 -right-1.5 flex gap-0.5">
-                            {#if is_icelandic}
-                              <svg class="h-2.5 w-3" viewBox="0 0 25 18" fill="none">
-                                <rect width="25" height="18" fill="#003897" />
-                                <rect x="7" width="4" height="18" fill="#fff" />
-                                <rect y="7" width="25" height="4" fill="#fff" />
-                                <rect x="8" width="2" height="18" fill="#D72828" />
-                                <rect y="8" width="25" height="2" fill="#D72828" />
-                              </svg>
-                            {/if}
-                            {#if is_3d}
-                              <span class="rounded bg-blue-600 px-0.5 text-[8px] font-bold text-white">3D</span>
-                            {/if}
-                            {#if is_luxus}
-                              <span class="rounded bg-yellow-500 px-0.5 text-[8px] font-bold text-black">LÚX</span>
-                            {/if}
-                            {#if is_vip}
-                              <span class="rounded bg-emerald-600 px-0.5 text-[8px] font-bold text-white">VIP</span>
-                            {/if}
-                            {#if is_atmos}
-                              <span class="rounded bg-purple-600 px-0.5 text-[8px] font-bold text-white">ÁSBERG</span>
-                            {/if}
-                            {#if is_max}
-                              <span class="rounded bg-red-600 px-0.5 text-[8px] font-bold text-white">MAX</span>
-                            {/if}
-                            {#if is_flauel}
-                              <span class="rounded bg-pink-500 px-0.5 text-[8px] font-bold text-white">FLAUEL</span>
-                            {/if}
-                          </span>
-                        {/if}
-                        {new Date(time).toLocaleTimeString("is-IS", { timeStyle: "short", hour12: false })}
-                      </a>
-                    {/each}
-                  </div>
-                </div>
+                <CinemaShowtimeRow {cinema} showtimes={validTimes} />
               {/if}
             {/if}
           {/each}

--- a/src/routes/movie/[id]/+page.svelte
+++ b/src/routes/movie/[id]/+page.svelte
@@ -42,7 +42,12 @@
     dayState.set(day);
   };
 
-  const current_showtimes = $derived(movie.showtimes_by_day[selected_day] ?? {});
+  const visible_showtimes = $derived.by(() =>
+    Object.entries(movie.showtimes_by_day[selected_day] ?? {})
+      .filter(([cinema]) => selected_cinemas.includes(cinema))
+      .map(([cinema, times]) => ({ cinema, showtimes: get_valid_showtimes(times, selected_day, from, to) }))
+      .filter(({ showtimes }) => showtimes.length > 0)
+  );
 </script>
 
 <svelte:head>
@@ -170,14 +175,14 @@
       {/if}
 
       <!-- Showtimes -->
-      <div class="pt-2">
-        <div class="mb-6 flex flex-wrap items-center gap-x-3 gap-y-2">
+      <div class="pt-2 md:max-w-3xl">
+        <div class="mb-5 flex flex-wrap items-center gap-x-3 gap-y-2">
           <DayPicker {selected_day} onSelect={updateDay} containerClass="shrink-0" />
           {#if selected_choice !== DEFAULT_CINEMA_CHOICE}
             <button
               type="button"
               onclick={() => cinemaState.set(DEFAULT_CINEMA_CHOICE)}
-              class="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-white/[0.06] py-1 pr-1.5 pl-3 text-xs font-medium text-neutral-300 shadow-[inset_0_1px_0_rgba(255,255,255,0.08)] backdrop-blur-xl transition-colors hover:bg-white/10 hover:text-white">
+              class="inline-flex min-h-8 items-center gap-1.5 rounded-full border border-white/10 bg-white/[0.06] py-1 pr-1.5 pl-3 text-xs font-medium text-neutral-300 shadow-[inset_0_1px_0_rgba(255,255,255,0.08)] backdrop-blur-xl transition-colors hover:bg-white/10 hover:text-white">
               <span class="max-w-[120px] truncate">{selected_choice}</span>
               <span class="flex h-4 w-4 items-center justify-center rounded-full bg-white/15 transition-colors hover:bg-white/25">
                 <svg class="h-2.5 w-2.5 text-neutral-200" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3">
@@ -189,16 +194,17 @@
         </div>
 
         <!-- eslint-disable svelte/no-navigation-without-resolve -->
-        <div class="space-y-3 md:max-w-3xl">
-          {#each Object.entries(current_showtimes) as [cinema, times] (cinema)}
-            {#if selected_cinemas.includes(cinema)}
-              {@const validTimes = get_valid_showtimes(times, selected_day, from, to)}
-              {#if validTimes.length > 0}
-                <CinemaShowtimeRow {cinema} showtimes={validTimes} />
-              {/if}
-            {/if}
-          {/each}
-        </div>
+        {#if visible_showtimes.length > 0}
+          <div class="space-y-3">
+            {#each visible_showtimes as { cinema, showtimes } (cinema)}
+              <CinemaShowtimeRow {cinema} {showtimes} />
+            {/each}
+          </div>
+        {:else}
+          <div class="rounded-2xl border border-white/[0.06] bg-white/[0.03] p-4 text-sm text-neutral-400">
+            Engar sýningar fundust fyrir þetta val.
+          </div>
+        {/if}
       </div>
     </div>
   </div>

--- a/src/scrape.ts
+++ b/src/scrape.ts
@@ -15,6 +15,7 @@ import {
   scrape_rotten_tomatoes,
   scrape_metacritic,
   scrape_letterboxd,
+  fetch_imdb_ratings,
   type HallInfo,
 } from "$lib/parse";
 
@@ -238,7 +239,11 @@ async function main() {
     }
   }
 
-  console.log(`Scraped ${movies.length} valid movies. Fetching external URLs and scores...`);
+  const imdbIds = movies.flatMap((movie) => movie.imdb?.link.match(/tt\d+/)?.[0] ?? []);
+  console.log(`Scraped ${movies.length} valid movies. Fetching IMDb ratings for ${imdbIds.length} movies...`);
+  const imdbRatings = await fetch_imdb_ratings(imdbIds);
+
+  console.log(`Fetched ${imdbRatings.size} IMDb ratings. Fetching external URLs and scores...`);
 
   // Fetch RT, Metacritic, and Letterboxd URLs from Wikidata, then scrape scores
   const moviesWithUrls = await Promise.all(
@@ -247,6 +252,9 @@ async function main() {
 
       const imdbId = movie.imdb.link.match(/tt\d+/)?.[0];
       if (!imdbId) return movie;
+
+      const imdbRating = imdbRatings.get(imdbId);
+      const imdb = imdbRating ? { ...movie.imdb, star: imdbRating.star } : movie.imdb?.star ? movie.imdb : undefined;
 
       await delay(100); // Rate limit Wikidata requests
       const { rtUrl, mcUrl, letterboxdUrl } = await fetch_external_urls(imdbId);
@@ -307,6 +315,7 @@ async function main() {
 
       return {
         ...movie,
+        imdb,
         rotten_tomatoes,
         metacritic,
         letterboxd,


### PR DESCRIPTION
## Summary
- Extract shared cinema, showtime, and video helpers
- Extract reusable Svelte UI components for cinema filters, poster cards, ratings, badges, and showtime rows
- Use IMDb public ratings dataset instead of persisting placeholder zero ratings
- Refresh movie detail showtime layout

## Checks
- nix fmt
- bun run check