### PR TITLE
Refine picker APIs and deduplicate showtimes

### DIFF
--- a/src/lib/CinemaSelect.svelte
+++ b/src/lib/CinemaSelect.svelte
@@ -5,9 +5,12 @@
     cinemaOptions: readonly CinemaOption[];
     selectedChoice: string;
     onSelect: (choice: string) => void;
+    id?: string;
+    size?: "sm" | "md";
   };
 
-  const { cinemaOptions, selectedChoice, onSelect }: Props = $props();
+  const { cinemaOptions, selectedChoice, onSelect, id = "select-cinemas", size = "md" }: Props = $props();
+  const sizeClass = $derived(size === "sm" ? "min-h-8 py-1 text-xs" : "py-1 text-sm");
 
   const handleChange = (event: Event & { currentTarget: HTMLSelectElement }) => {
     onSelect(event.currentTarget.value);
@@ -18,10 +21,10 @@
   <select
     value={selectedChoice}
     onchange={handleChange}
-    id="select-cinemas-mobile"
-    name="select cinemas mobile"
+    {id}
+    name={id}
     aria-label="Veldu kvikmyndahús"
-    class="appearance-none rounded-full border border-white/10 bg-black/70 py-1 pr-8 pl-8 text-center text-sm font-medium text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.1),0_4px_14px_rgba(0,0,0,0.26)] focus:border-sky-300/40 focus:ring-2 focus:ring-sky-300/15 focus:outline-none">
+    class="appearance-none rounded-full border border-white/10 bg-black/70 pr-8 pl-8 text-center font-medium text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.1),0_4px_14px_rgba(0,0,0,0.26)] focus:border-sky-300/40 focus:ring-2 focus:ring-sky-300/15 focus:outline-none {sizeClass}">
     {#each cinemaOptions as [label] (label)}
       <option
         value={label}

--- a/src/lib/DayPicker.svelte
+++ b/src/lib/DayPicker.svelte
@@ -2,21 +2,23 @@
   import { AVAILABLE_DAYS, get_day_label } from "$lib/day-picker";
 
   type Props = {
-    selected_day: string;
+    selectedDay: string;
     onSelect: (day: string) => void;
     days?: string[];
-    containerClass?: string;
-    buttonClass?: string;
+    size?: "sm" | "md";
+    shrink?: boolean;
   };
 
-  const { selected_day, onSelect, days = AVAILABLE_DAYS, containerClass = "", buttonClass = "py-1.5" }: Props = $props();
+  const { selectedDay, onSelect, days = AVAILABLE_DAYS, size = "md", shrink = false }: Props = $props();
+  const buttonSizeClass = $derived(size === "sm" ? "py-1.25" : "py-1.5");
+  const containerSizeClass = $derived(shrink ? "shrink-0" : "");
 
   let day_buttons: HTMLButtonElement[] = $state([]);
   let slider_style = $state("width: 0; left: 0; opacity: 0;");
   let slider_animated = $state(false);
 
   $effect(() => {
-    const idx = days.indexOf(selected_day);
+    const idx = days.indexOf(selectedDay);
     const btn = day_buttons[idx];
     if (btn) {
       slider_style = `width: ${btn.offsetWidth}px; left: ${btn.offsetLeft}px; opacity: 1;`;
@@ -30,7 +32,7 @@
 </script>
 
 <div
-  class="relative flex items-center overflow-hidden rounded-full border border-white/10 bg-neutral-950/65 p-0.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.12),0_6px_22px_rgba(0,0,0,0.3)] backdrop-blur-xl {containerClass}">
+  class="relative flex items-center overflow-hidden rounded-full border border-white/10 bg-neutral-950/65 p-0.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.12),0_6px_22px_rgba(0,0,0,0.3)] backdrop-blur-xl {containerSizeClass}">
   <div
     class="absolute h-[calc(100%-6px)] rounded-full border border-sky-200/20 bg-sky-500/65 shadow-[inset_0_1px_0_rgba(255,255,255,0.3),0_3px_10px_rgba(14,165,233,0.22)] backdrop-blur-md {slider_animated
       ? 'transition-all duration-300 ease-out'
@@ -42,7 +44,7 @@
       bind:this={day_buttons[i]}
       type="button"
       onclick={() => onSelect(day)}
-      class="relative z-10 rounded-full px-2.5 text-[13px] leading-4 font-medium transition-colors duration-200 {buttonClass} {selected_day ===
+      class="relative z-10 rounded-full px-2.5 text-[13px] leading-4 font-medium transition-colors duration-200 {buttonSizeClass} {selectedDay ===
       day
         ? 'text-white'
         : 'text-neutral-400 hover:text-neutral-200'}">

--- a/src/lib/showtimes.ts
+++ b/src/lib/showtimes.ts
@@ -11,8 +11,21 @@ export const is_valid_showtime = (showtime: Showtime, selected_day: string, from
   return Boolean(showtime.time && in_range(to_float(showtime.time), from, to));
 };
 
-export const get_valid_showtimes = (showtimes: readonly Showtime[], selected_day: string, from: number, to: number) =>
-  showtimes.filter((showtime) => is_valid_showtime(showtime, selected_day, from, to));
+const get_showtime_key = (showtime: Showtime) => `${showtime.time}-${showtime.purchase_url}`;
+
+export const get_valid_showtimes = (showtimes: readonly Showtime[], selected_day: string, from: number, to: number) => {
+  const seen = new Set<string>();
+
+  return showtimes.filter((showtime) => {
+    if (!is_valid_showtime(showtime, selected_day, from, to)) return false;
+
+    const key = get_showtime_key(showtime);
+    if (seen.has(key)) return false;
+
+    seen.add(key);
+    return true;
+  });
+};
 
 export const count_movie_showtimes = (
   movie: Movie,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -51,7 +51,7 @@
     <CinemaTabs cinemaOptions={cinema_options} selectedChoice={selected_choice} onSelect={updateCinema} />
     <!-- Day selection -->
     <div class="flex justify-center">
-      <DayPicker {selected_day} onSelect={updateDay} />
+      <DayPicker selectedDay={selected_day} onSelect={updateDay} />
     </div>
   </div>
 </header>
@@ -65,7 +65,7 @@
       </div>
       <!-- Day pills -->
       <div class="flex justify-center">
-        <DayPicker {selected_day} onSelect={updateDay} buttonClass="py-1.25" />
+        <DayPicker selectedDay={selected_day} onSelect={updateDay} size="sm" />
       </div>
     </div>
   </div>

--- a/src/routes/movie/[id]/+page.svelte
+++ b/src/routes/movie/[id]/+page.svelte
@@ -3,6 +3,7 @@
   import { get_youtube_id, is_mobile_user_agent } from "$lib/video";
   import { DEFAULT_CINEMA_CHOICE, get_cinemas_for_choice, cinemaState } from "$lib/cinema-state.svelte";
   import { dayState } from "$lib/day-state.svelte";
+  import CinemaSelect from "$lib/CinemaSelect.svelte";
   import DayPicker from "$lib/DayPicker.svelte";
   import MovieRatings from "$lib/MovieRatings.svelte";
   import CinemaShowtimeRow from "$lib/CinemaShowtimeRow.svelte";
@@ -42,6 +43,10 @@
     dayState.set(day);
   };
 
+  const updateCinema = (choice: string) => {
+    cinemaState.set(choice);
+  };
+
   const visible_showtimes = $derived.by(() =>
     Object.entries(movie.showtimes_by_day[selected_day] ?? {})
       .filter(([cinema]) => selected_cinemas.includes(cinema))
@@ -54,7 +59,7 @@
   <link rel="preload" as="image" href="/{movie.id}-360w.webp" fetchpriority="high" />
 </svelte:head>
 
-<div class="container mx-auto max-w-7xl py-4 md:px-8 md:py-8 lg:px-12 lg:py-10">
+<div class="container mx-auto max-w-7xl py-4 pb-28 md:px-8 md:py-8 lg:px-12 lg:py-10">
   <button
     type="button"
     onclick={() => history.back()}
@@ -176,21 +181,14 @@
 
       <!-- Showtimes -->
       <div class="pt-2 md:max-w-3xl">
-        <div class="mb-5 flex flex-wrap items-center gap-x-3 gap-y-2">
-          <DayPicker {selected_day} onSelect={updateDay} containerClass="shrink-0" />
-          {#if selected_choice !== DEFAULT_CINEMA_CHOICE}
-            <button
-              type="button"
-              onclick={() => cinemaState.set(DEFAULT_CINEMA_CHOICE)}
-              class="inline-flex min-h-8 items-center gap-1.5 rounded-full border border-white/10 bg-white/[0.06] py-1 pr-1.5 pl-3 text-xs font-medium text-neutral-300 shadow-[inset_0_1px_0_rgba(255,255,255,0.08)] backdrop-blur-xl transition-colors hover:bg-white/10 hover:text-white">
-              <span class="max-w-[120px] truncate">{selected_choice}</span>
-              <span class="flex h-4 w-4 items-center justify-center rounded-full bg-white/15 transition-colors hover:bg-white/25">
-                <svg class="h-2.5 w-2.5 text-neutral-200" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-                </svg>
-              </span>
-            </button>
-          {/if}
+        <div class="mb-5 hidden flex-wrap items-center gap-x-3 gap-y-2 sm:flex">
+          <DayPicker selectedDay={selected_day} onSelect={updateDay} shrink />
+          <CinemaSelect
+            cinemaOptions={cinema_options}
+            selectedChoice={selected_choice}
+            onSelect={updateCinema}
+            id="select-cinemas-movie-desktop"
+            size="sm" />
         </div>
 
         <!-- eslint-disable svelte/no-navigation-without-resolve -->
@@ -206,6 +204,21 @@
           </div>
         {/if}
       </div>
+    </div>
+  </div>
+</div>
+
+<div class="fixed inset-x-0 bottom-0 z-40 flex w-full justify-center px-4 pb-3 sm:hidden">
+  <div class="flex flex-col items-center gap-2">
+    <div class="flex justify-center">
+      <CinemaSelect
+        cinemaOptions={cinema_options}
+        selectedChoice={selected_choice}
+        onSelect={updateCinema}
+        id="select-cinemas-movie-mobile" />
+    </div>
+    <div class="flex justify-center">
+      <DayPicker selectedDay={selected_day} onSelect={updateDay} size="sm" />
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Make picker component APIs more explicit and Svelte 5-friendly
- Add movie detail cinema dropdown on desktop and fixed mobile controls
- Deduplicate duplicate showtimes by time and purchase URL

## Checks
- nix fmt
- bun run check