### PR TITLE
Trust full kvikmyndir TLS chain

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,16 +17,16 @@ jobs:
       - name: 📚 Install node dependencies
         run: bun install
 
-      - name: 🔐 Trust missing TLS intermediate for kvikmyndir.is
+      - name: 🔐 Trust TLS certificate chain for kvikmyndir.is
         run: |
-          openssl s_client -connect www.kvikmyndir.is:443 -servername www.kvikmyndir.is -showcerts </dev/null 2>/dev/null \
-            | awk '/BEGIN CERTIFICATE/{flag=1} flag{print} /END CERTIFICATE/{exit}' > "$RUNNER_TEMP/kvikmyndir-leaf.pem"
+          openssl s_client \
+            -connect www.kvikmyndir.is:443 \
+            -servername www.kvikmyndir.is \
+            -showcerts </dev/null 2>/dev/null \
+            | awk '/BEGIN CERTIFICATE/,/END CERTIFICATE/' \
+            > "$RUNNER_TEMP/kvikmyndir-chain.pem"
 
-          issuer_url=$(openssl x509 -in "$RUNNER_TEMP/kvikmyndir-leaf.pem" -noout -text | awk -F'URI:' '/CA Issuers - URI:/{print $2; exit}')
-          curl -fsSL "$issuer_url" -o "$RUNNER_TEMP/kvikmyndir-issuer.der"
-          openssl x509 -inform DER -in "$RUNNER_TEMP/kvikmyndir-issuer.der" -out "$RUNNER_TEMP/kvikmyndir-issuer.pem"
-
-          echo "NODE_EXTRA_CA_CERTS=$RUNNER_TEMP/kvikmyndir-issuer.pem" >> "$GITHUB_ENV"
+          echo "NODE_EXTRA_CA_CERTS=$RUNNER_TEMP/kvikmyndir-chain.pem" >> "$GITHUB_ENV"
 
       - name: 🎬 Scrape movie data
         run: bun scrape


### PR DESCRIPTION
## Summary
- capture the complete certificate chain served by kvikmyndir.is
- expose that chain to Bun through `NODE_EXTRA_CA_CERTS`
- remove the single-intermediate download workaround

## Verification
- `nix fmt`
- fetched the scrape URL with Bun using the captured chain