### PR TITLE
Fix single-tap poster navigation on iOS Safari

### DIFF
--- a/src/lib/MoviePosterCard.svelte
+++ b/src/lib/MoviePosterCard.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { resolve } from "$app/paths";
-  import { fade } from "svelte/transition";
 
   import { movie_path_segment } from "$lib/movie-path";
   import type { Movie } from "$lib/schemas";
@@ -19,8 +18,7 @@
 <a
   href={movieHref}
   data-movie-id={movie.id}
-  in:fade={{ duration: 280, delay: Math.min(index, 12) * 30 }}
-  class="group block aspect-2/3 w-full touch-manipulation overflow-visible rounded-lg bg-neutral-900 [@media(hover:hover)]:hover:z-50"
+  class="movie-poster-card block aspect-2/3 w-full touch-manipulation overflow-visible rounded-lg bg-neutral-900"
   style="-webkit-tap-highlight-color: transparent; touch-action: manipulation; user-select: none; -webkit-user-select: none;">
   <picture>
     <source
@@ -30,13 +28,35 @@
     <img
       src="/{movie.id}.webp"
       alt={movie.title}
-      title={movie.title}
       fetchpriority={index < 4 ? "high" : "auto"}
       loading="eager"
       decoding="async"
       width="720"
       height="1080"
       style:view-transition-name="poster-{movie.id}"
-      class="shadow-5xl pointer-events-none h-full w-full rounded-lg object-fill [@media(hover:hover)]:transition-all [@media(hover:hover)]:duration-300 [@media(hover:hover)]:ease-out [@media(hover:hover)]:group-hover:scale-[1.02] [@media(hover:hover)]:group-hover:shadow-2xl [@media(hover:hover)]:group-hover:brightness-110" />
+      class="movie-poster-image shadow-5xl pointer-events-none h-full w-full rounded-lg object-fill" />
   </picture>
 </a>
+
+<style>
+  /* iOS Safari can turn a touch into a sticky :hover and require a second tap.
+     Keep hover selectors entirely outside coarse-pointer devices. */
+  @media (hover: hover) and (pointer: fine) {
+    .movie-poster-card:hover {
+      z-index: 50;
+    }
+
+    .movie-poster-image {
+      transition:
+        transform 300ms ease-out,
+        filter 300ms ease-out,
+        box-shadow 300ms ease-out;
+    }
+
+    .movie-poster-card:hover .movie-poster-image {
+      transform: scale(1.02);
+      filter: brightness(1.1);
+      box-shadow: 0 25px 50px -12px rgb(0 0 0 / 0.25);
+    }
+  }
+</style>

--- a/src/lib/MoviePosterCard.svelte
+++ b/src/lib/MoviePosterCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { goto } from "$app/navigation";
   import { resolve } from "$app/paths";
 
   import { movie_path_segment } from "$lib/movie-path";
@@ -12,12 +13,38 @@
 
   const { movie, catalog, index }: Props = $props();
   const movieHref = $derived(resolve(`/movie/${movie_path_segment(movie, catalog)}`));
+
+  let touchStart: { x: number; y: number } | null = null;
+
+  const handleTouchStart = (event: TouchEvent) => {
+    const touch = event.touches[0];
+    touchStart = touch ? { x: touch.clientX, y: touch.clientY } : null;
+  };
+
+  const handleTouchEnd = (event: TouchEvent) => {
+    const touch = event.changedTouches[0];
+    if (!touchStart || !touch) return;
+
+    const movement = Math.hypot(touch.clientX - touchStart.x, touch.clientY - touchStart.y);
+    touchStart = null;
+    if (movement >= 10) return;
+
+    // iOS Safari can retain the previously tapped link's hover state after
+    // history navigation and consume the next synthetic click. Navigate from
+    // the real touch event instead; preventDefault suppresses the later click.
+    event.preventDefault();
+    // eslint-disable-next-line svelte/no-navigation-without-resolve
+    void goto(movieHref);
+  };
 </script>
 
 <!-- eslint-disable svelte/no-navigation-without-resolve -->
 <a
   href={movieHref}
   data-movie-id={movie.id}
+  ontouchstart={handleTouchStart}
+  ontouchend={handleTouchEnd}
+  ontouchcancel={() => (touchStart = null)}
   class="movie-poster-card block aspect-2/3 w-full touch-manipulation overflow-visible rounded-lg bg-neutral-900"
   style="-webkit-tap-highlight-color: transparent; touch-action: manipulation; user-select: none; -webkit-user-select: none;">
   <picture>


### PR DESCRIPTION
## Summary
- restrict poster hover behavior to fine-pointer devices
- remove touch-sensitive poster entrance and title behavior
- navigate directly from genuine touch events so iOS Safari cannot consume the first synthetic click
- preserve native mouse and keyboard link behavior

## Validation
- `nix fmt`
- `bun run check`
- `bun test` (42 tests)