### PR TITLE
Use ASCII movie slugs

### DIFF
--- a/src/lib/cinemas.ts
+++ b/src/lib/cinemas.ts
@@ -14,7 +14,7 @@ export const get_cinema_options = (movies: readonly Movie[]): readonly CinemaOpt
   const capital_region_cinemas = all_cinemas.filter((name) => (CAPITAL_REGION_CINEMAS as readonly string[]).includes(name));
 
   return [
-    ["Öll kvikmyndahús", all_cinemas],
+    ["Allt", all_cinemas],
     ["Höfuðborgarsvæðið", capital_region_cinemas],
     ...all_cinemas.map((name) => [CINEMA_DISPLAY_NAMES[name] ?? name, [name]] as const),
   ] as const;

--- a/src/lib/movie-path.ts
+++ b/src/lib/movie-path.ts
@@ -5,8 +5,12 @@ type MovieIdentity = Pick<Movie, "id" | "title">;
 const title_slug = (title: string) =>
   title
     .toLocaleLowerCase("is")
-    .normalize("NFC")
-    .replace(/[^\p{L}\p{N}]+/gu, "-")
+    .replace(/ð/g, "d")
+    .replace(/þ/g, "th")
+    .replace(/æ/g, "ae")
+    .normalize("NFD")
+    .replace(/\p{M}/gu, "")
+    .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-|-$/g, "");
 
 export const movie_path_segment = (movie: MovieIdentity, catalog: readonly MovieIdentity[]) => {

--- a/tests/movie-path.test.ts
+++ b/tests/movie-path.test.ts
@@ -4,12 +4,14 @@ import { find_movie_by_path, movie_path_segment } from "../src/lib/movie-path";
 const movies = [
   { id: 18679, title: "Hvar er draumurinn?" },
   { id: 42, title: "Þrír á ferð með Æsu" },
+  { id: 43, title: "Um tímann og vatnið" },
 ];
 
 describe("movie paths", () => {
-  test("keeps Icelandic letters and omits IDs from unique titles", () => {
+  test("transliterates Icelandic letters and omits IDs from unique titles", () => {
     expect(movie_path_segment(movies[0], movies)).toBe("hvar-er-draumurinn");
-    expect(movie_path_segment(movies[1], movies)).toBe("þrír-á-ferð-með-æsu");
+    expect(movie_path_segment(movies[1], movies)).toBe("thrir-a-ferd-med-aesu");
+    expect(movie_path_segment(movies[2], movies)).toBe("um-timann-og-vatnid");
   });
 
   test("adds IDs only when titles collide", () => {
@@ -23,7 +25,7 @@ describe("movie paths", () => {
   });
 
   test("finds readable paths and preserves legacy numeric paths", () => {
-    expect(find_movie_by_path(movies, "þrír-á-ferð-með-æsu")?.id).toBe(42);
+    expect(find_movie_by_path(movies, "thrir-a-ferd-med-aesu")?.id).toBe(42);
     expect(find_movie_by_path(movies, "42")?.id).toBe(42);
     expect(find_movie_by_path(movies, "missing")?.id).toBeUndefined();
   });


### PR DESCRIPTION
## Summary
- transliterate Icelandic movie titles to URL-safe ASCII slugs
- rename the all-cinemas option from “Öll kvikmyndahús” to “Allt”

## Validation
- `nix fmt`
- `bun test tests/movie-path.test.ts`
- `bun run check`