### PR TITLE
ci: refresh Nix and Bun dependencies nightly

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,0 +1,70 @@
+name: Update dependencies
+
+on:
+  schedule:
+    - cron: "23 3 * * *" # Nightly at 03:23 UTC (Iceland time)
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: update-dependencies
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@main
+        with:
+          ref: main
+      - uses: cachix/install-nix-action@v31
+      - uses: oven-sh/setup-bun@main
+        with:
+          bun-version: latest
+
+      - name: Update Nix inputs
+        run: nix flake update
+
+      - name: Update Bun dependencies within their declared ranges
+        run: bun update
+
+      - name: Format updated files
+        run: |
+          nix fmt
+          bunx --no-install prettier --write package.json
+
+      # PRs created with GITHUB_TOKEN do not trigger pull_request workflows,
+      # so validate the updates here before opening or refreshing the PR.
+      - name: Validate updated dependencies
+        run: |
+          bun install --frozen-lockfile
+          mkdir -p static
+          echo '[]' > static/movies.json
+          bun test
+          bun run check
+          bun run build
+        env:
+          ADAPTER: cloudflare
+          NODE_ENV: production
+
+      - uses: peter-evans/create-pull-request@v8
+        with:
+          branch: automation/nightly-dependencies
+          delete-branch: true
+          add-paths: |
+            flake.lock
+            package.json
+            bun.lock
+            bun.lockb
+          commit-message: "deps: keep Nix inputs and Bun dependencies current"
+          title: "deps: keep Nix inputs and Bun dependencies current"
+          body: |
+            Refresh Nix inputs and Bun dependencies nightly to keep the project current.
+            Bun dependency updates stay within the ranges declared in package.json.
+
+            Validated with nix fmt, a frozen Bun install, bun test, bun run check,
+            and a Cloudflare build before opening this pull request.

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787360063,
-        "narHash": "sha256-dt4WdcvsA8/RCe+VZZwqU0X+XMM3wBbGCWA0/sFWzGo=",
+        "lastModified": 1788614874,
+        "narHash": "sha256-7QYjT2vHLuX9Z1pdxHXDKCbh1CR3D/2rywB9Tx0MPRg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2c423e03bbafcff28bfadc6781a4a8257f205cb5",
+        "rev": "c043004d1c6985732bcc1cbc5a9c9aecbbb4e0f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Dependencies currently require manual refreshes. Add a nightly workflow at 03:23 UTC that updates `flake.lock` and Bun dependencies within their declared ranges, then opens or refreshes one pull request. Include the current nixpkgs snapshot refresh as a separate commit.

The workflow validates updates before creating the PR because PRs created with `GITHUB_TOKEN` do not trigger the existing pull-request workflow. It also supports manual runs.

Validation: `nix fmt`, Prettier, actionlint, 42 passing tests, `bun run check`, and a Cloudflare production build. Stale generated Svelte output was cleared before the successful application check.

Bun in the Nix development shell remains 1.3.13 because that is the version packaged by the selected nixos-unstable snapshot. The updater uses the latest upstream Bun via setup-bun.
