### PR TITLE
ci: generate Svelte aliases before running Bun tests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,3 +13,4 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: mkdir -p static && echo '[]' > static/movies.json
       - run: bun run check
+      - run: bun test

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -44,8 +44,9 @@ jobs:
           bun install --frozen-lockfile
           mkdir -p static
           echo '[]' > static/movies.json
-          bun test
+          # check runs svelte-kit sync, generating the $lib alias for Bun tests.
           bun run check
+          bun test
           bun run build
         env:
           ADAPTER: cloudflare


### PR DESCRIPTION
Nightly updates fail on clean checkouts because Bun tests import `$lib/parse` before SvelteKit has generated its alias configuration. Run `bun run check` (which invokes `svelte-kit sync`) before `bun test`, and run tests after the application check in regular PR CI as well.

Reproduced the exact missing-module error without `.svelte-kit`, then verified the corrected sequence with a frozen install, application checks, all 42 tests, and a Cloudflare build on local Bun 1.3.13. Formatting (`nix fmt`, Prettier) and actionlint also pass. PR CI uses the latest Bun to validate the reported 1.4.2 environment.
