### PR TITLE
ci: expose dispatched dependency results to branch protection

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,3 +14,29 @@ jobs:
       - run: mkdir -p static && echo '[]' > static/movies.json
       - run: bun run check
       - run: bun test
+
+  # Dispatched checks can be absent from the PR's required-check rollup.
+  # Publish the actual test result on the same commit for branch protection.
+  dependency-status:
+    if: >-
+      always() && github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/automation/nightly-dependencies'
+    needs: bun-check
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - name: Report dependency check result
+        run: |
+          gh api --method POST "repos/$GH_REPO/statuses/$CHECK_SHA" \
+            -f context=bun-check \
+            -f state="$CHECK_STATE" \
+            -f description="Dependency checks: $CHECK_RESULT" \
+            -f target_url="$CHECK_URL"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          CHECK_SHA: ${{ github.sha }}
+          CHECK_RESULT: ${{ needs.bun-check.result }}
+          CHECK_STATE: ${{ needs.bun-check.result == 'success' && 'success' || 'failure' }}
+          CHECK_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
A dispatched `bun-check` passed on dependency PR #44's exact head, but GitHub reported an empty PR check rollup and kept auto-merge blocked. Publish the actual test result as a commit status so branch protection can observe it.

The reporting job runs only for dispatches on the nightly dependency branch, executes no repository code, and has only `statuses: write`. Failed, skipped, or cancelled tests report failure. The required `bun-check` and native GitHub auto-merge remain in place.

Validation: reproduced with run 34240598813 and PR #44; `nix fmt`, Prettier, actionlint, and diff checks pass. Live validation follows after merge.
